### PR TITLE
Feat/add pg admin

### DIFF
--- a/.env
+++ b/.env
@@ -5,6 +5,9 @@ DB_NAME=TesloDB
 DB_PORT=5432
 DB_USER=postgres
 
+PGADMIN_EMAIL=admin@admin.com
+PGADMIN_PASSWORD=root
+
 PORT=3000
 HOST_API=http://localhost:3000/api
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,3 +12,14 @@ services:
     container_name: teslodb
     volumes:
       - ./postgres:/var/lib/postgresql/data
+  pgadmin:
+    container_name: pgadmin
+    image: dpage/pgadmin4
+    restart: always
+    ports:
+      - "80:80"
+    environment:
+      PGADMIN_DEFAULT_EMAIL: ${PGADMIN_EMAIL}
+      PGADMIN_DEFAULT_PASSWORD: ${PGADMIN_PASSWORD}
+    depends_on:
+      - db

--- a/src/auth/auth.controller.ts
+++ b/src/auth/auth.controller.ts
@@ -24,6 +24,7 @@ export class AuthController {
   constructor(private readonly authService: AuthService) {}
 
   @Post('register')
+  // @Auth(ValidRoles.superUser, ValidRoles.admin)
   create(@Body() createUserDto: CreateUserDto) {
     return this.authService.create(createUserDto);
   }


### PR DESCRIPTION
se agrego pg admin al docker-compose.yml file y se verifico que dicha implementacion funcione, para utilizarlo solo debe de abrirse un navegador y escribir localhost, esperar a que aparezca el administrador pgAdmin